### PR TITLE
#167484554 Pagination support for articles

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11117,6 +11117,11 @@
       "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
       "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ=="
     },
+    "paginator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/paginator/-/paginator-1.0.0.tgz",
+      "integrity": "sha1-dWVwKvmrlhbcph/CLHDroqQ1cmU="
+    },
     "pako": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.10.tgz",
@@ -12661,6 +12666,17 @@
       "version": "16.9.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.9.0.tgz",
       "integrity": "sha512-tJBzzzIgnnRfEm046qRcURvwQnZVXmuCbscxUO5RWrGTXpon2d4c8mI0D8WE6ydVIm29JiLB6+RslkIvym9Rjw=="
+    },
+    "react-js-pagination": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/react-js-pagination/-/react-js-pagination-3.0.2.tgz",
+      "integrity": "sha512-gsXaQVis1YDKhbeZC7VT9dsSWyZ8GZNEX06dy2HLl36LohY2Vt/iWJ5k6HAb0YOKW0mklCY7wjxJIfJeeP295g==",
+      "requires": {
+        "classnames": "^2.2.5",
+        "paginator": "^1.0.0",
+        "prop-types": "15.x.x - 16.x.x",
+        "react": "15.x.x - 16.x.x"
+      }
     },
     "react-lifecycles-compat": {
       "version": "3.0.4",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "react": "^16.9.0",
     "react-dom": "^16.9.0",
     "react-html-parser": "^2.0.2",
+    "react-js-pagination": "^3.0.2",
     "react-redux": "^7.1.1",
     "react-redux-modal-flex": "^2.0.0",
     "react-router-dom": "^5.0.1",

--- a/src/app/common/pagination/Pagination.scss
+++ b/src/app/common/pagination/Pagination.scss
@@ -40,17 +40,5 @@
         height: 30px;
       }
     }
-    .disabled {
-      a {
-        cursor: not-allowed;
-        color: black;
-        background: white;
-        box-shadow: none;
-        font-weight: bold;
-        padding: 8px 15px;
-        width: 30px;
-        height: 30px;
-      }
-    }
   }
 }

--- a/src/app/common/pagination/Pagination.scss
+++ b/src/app/common/pagination/Pagination.scss
@@ -1,0 +1,56 @@
+.pagination-container {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  padding-top: 30px;
+  padding-bottom: 30px;
+
+  .pagination {
+    margin: 0;
+    padding: 0;
+    list-style-type: none;
+    li {
+      display: inline-block;
+      text-align: center;
+      margin: 2px 5px;
+
+      a {
+        cursor: pointer;
+        color: black;
+        background: white;
+        font-weight: bold;
+        box-shadow: 1px 3px lightgray;
+        padding: 8px 15px;
+        width: 30px;
+        height: 30px;
+        text-decoration: none;
+      }
+    }
+
+    .active {
+      background: #2b9ff2;
+      a {
+        cursor: pointer;
+        color: white;
+        background: #2b9ff2;
+        font-weight: bold;
+        box-shadow: 1px 3px lightgray;
+        padding: 8px 15px;
+        width: 30px;
+        height: 30px;
+      }
+    }
+    .disabled {
+      a {
+        cursor: not-allowed;
+        color: black;
+        background: white;
+        box-shadow: none;
+        font-weight: bold;
+        padding: 8px 15px;
+        width: 30px;
+        height: 30px;
+      }
+    }
+  }
+}

--- a/src/app/common/pagination/PaginationComonent.js
+++ b/src/app/common/pagination/PaginationComonent.js
@@ -29,6 +29,9 @@ export class PaginationComonent extends Component {
             pageRangeDisplayed={3}
             onChange={this.handlePageChange}
             hideNavigation
+            firstPageText="First"
+            lastPageText="Last"
+            hideDisabled
           />
         </div>
       </div>

--- a/src/app/common/pagination/PaginationComonent.js
+++ b/src/app/common/pagination/PaginationComonent.js
@@ -1,0 +1,39 @@
+import React, { Component } from 'react';
+import Pagination from 'react-js-pagination';
+import './Pagination.scss';
+
+export class PaginationComonent extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      activePage: 1,
+    };
+  }
+
+  handlePageChange = (pageNumber) => {
+    const { getAllArticles } = this.props;
+    getAllArticles(pageNumber);
+    this.setState({ activePage: pageNumber });
+  };
+
+  render() {
+    const { activePage } = this.state;
+    const { articleNumbers } = this.props;
+    return (
+      <div>
+        <div className="pagination-container">
+          <Pagination
+            activePage={activePage}
+            itemsCountPerPage={10}
+            totalItemsCount={articleNumbers}
+            pageRangeDisplayed={3}
+            onChange={this.handlePageChange}
+            hideNavigation
+          />
+        </div>
+      </div>
+    );
+  }
+}
+
+export default PaginationComonent;

--- a/src/app/common/pagination/__tests__/PaginationCompon.test.js
+++ b/src/app/common/pagination/__tests__/PaginationCompon.test.js
@@ -27,7 +27,7 @@ describe('Pagination Component Tests', () => {
   it('should find number of li in pagination component', () => {
     expect(li.length).toEqual(3);
   });
-  it('should test handlePageChange function', () => {
+  it('should invoke handlePageChange function', () => {
     const paginator = jest.fn().mockImplementation(() => undefined);
     const instance = Wrapper.instance();
     Wrapper.instance().handlePageChange = paginator;

--- a/src/app/common/pagination/__tests__/PaginationCompon.test.js
+++ b/src/app/common/pagination/__tests__/PaginationCompon.test.js
@@ -25,13 +25,13 @@ describe('Pagination Component Tests', () => {
     expect(div.length).toEqual(2);
   });
   it('should find number of li in pagination component', () => {
-    expect(li.length).toEqual(3);
+    expect(li.length).toEqual(1);
   });
   it('should invoke handlePageChange function', () => {
     const paginator = jest.fn().mockImplementation(() => undefined);
     const instance = Wrapper.instance();
     Wrapper.instance().handlePageChange = paginator;
-    li.at(1).simulate('click');
+    li.at(0).simulate('click');
     const updateState = instance.handlePageChange(1);
     expect(updateState).toBe(undefined);
     expect(paginator).toHaveBeenCalledTimes(1);

--- a/src/app/common/pagination/__tests__/PaginationCompon.test.js
+++ b/src/app/common/pagination/__tests__/PaginationCompon.test.js
@@ -1,0 +1,39 @@
+/* eslint-disable react/jsx-props-no-spreading */
+import React from 'react';
+import { mount } from 'enzyme';
+import { PaginationComonent } from '../PaginationComonent';
+
+const renderPagination = (args) => {
+  const defaultProps = {
+    getAllArticles: jest.fn(),
+    activePage: 1,
+    articleNumbers: 10,
+  };
+  const props = { ...defaultProps, ...args };
+  return mount(<PaginationComonent {...props} />);
+};
+
+const Wrapper = renderPagination();
+const div = Wrapper.find('div');
+const li = Wrapper.find('li');
+
+describe('Pagination Component Tests', () => {
+  it('should render the component', () => {
+    expect(Wrapper.exists()).toBe(true);
+  });
+  it('should find number of divs in pagination component', () => {
+    expect(div.length).toEqual(2);
+  });
+  it('should find number of li in pagination component', () => {
+    expect(li.length).toEqual(3);
+  });
+  it('should test handlePageChange function', () => {
+    const paginator = jest.fn().mockImplementation(() => undefined);
+    const instance = Wrapper.instance();
+    Wrapper.instance().handlePageChange = paginator;
+    li.at(1).simulate('click');
+    const updateState = instance.handlePageChange(1);
+    expect(updateState).toBe(undefined);
+    expect(paginator).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/feature/articles/getArticles/GetAllArticlesAction.js
+++ b/src/feature/articles/getArticles/GetAllArticlesAction.js
@@ -3,13 +3,13 @@ import { toast } from 'react-toastify';
 import { GET_ARTICLES_SUCCESS, GET_ARTICLES_FAIL, LOADING } from '../constants';
 import { BACKEND_URL } from '../../../app/common/config/appConfig';
 
-const getAllArticles = () => async dispatch => {
+const getAllArticles = (page) => async dispatch => {
   try {
     dispatch({
       type: LOADING,
       payload: true
     });
-    const res = await axios.get(`${BACKEND_URL}/articles/`);
+    const res = await axios.get(`${BACKEND_URL}/articles?page=${page}&limit=10`);
 
     dispatch({
       type: GET_ARTICLES_SUCCESS,

--- a/src/feature/articles/getArticles/GetAllArticlesComponent.js
+++ b/src/feature/articles/getArticles/GetAllArticlesComponent.js
@@ -10,11 +10,20 @@ import avatar from '../../../app/common/images/avatar.png';
 import getAllArticles from './GetAllArticlesAction';
 import LikeDilsikeArticle from '../likeDislikeArticles/LikeDislikeComponent';
 import CommentCountComponent from '../../../app/common/CommentCount/CommentCountComponent';
+import Pagination from '../../../app/common/pagination/PaginationComonent';
 import './GetAllArticles.scss';
 
 export class GetAllArticles extends Component {
+  constructor() {
+    super();
+    this.state = {
+      activePage: 1,
+    };
+  }
+
   componentDidMount() {
-    this.props.getAllArticles();
+    const { activePage } = this.state;
+    this.props.getAllArticles(activePage);
   }
 
   render() {
@@ -24,7 +33,9 @@ export class GetAllArticles extends Component {
         <div className="main--banner">
           <div className="main--banner__text">
             <h1 className="heading__3">
-              Authors <br />
+              Authors 
+{' '}
+<br />
               Haven
             </h1>
             <h3 className="heading__4">Create and Read Articles</h3>
@@ -108,11 +119,19 @@ export class GetAllArticles extends Component {
             ) : (
               <div className="article__error">
                 <h2>
-                  Sorry No Articles Found At The Moment. <br />
+                  Sorry No Articles Found At The Moment. 
+{' '}
+<br />
                   Please Create one or comeback later!!!
                 </h2>
               </div>
             )}
+            <div>
+              <Pagination
+                getAllArticles={this.props.getAllArticles}
+                articleNumbers={this.props.totalArticleNum}
+              />
+            </div>
           </div>
         )}
       </div>
@@ -122,7 +141,8 @@ export class GetAllArticles extends Component {
 
 const mapStateToProps = state => ({
   articles: state.getAllArticles.articles,
-  loading: state.getAllArticles.loading
+  loading: state.getAllArticles.loading,
+  totalArticleNum: state.getAllArticles.articlesCount
 });
 const mapDispatchToProps = {
   getAllArticles

--- a/src/feature/articles/getArticles/__tests__/GetAllArticlesComponent.test.js
+++ b/src/feature/articles/getArticles/__tests__/GetAllArticlesComponent.test.js
@@ -26,7 +26,7 @@ describe('Get All Articles Components tests', () => {
   it('Should render a form inputs', () => {
     wrapper.setState({ loading: false });
     expect(wrapper.find('.mainDiv').length).toBe(1);
-    expect(wrapper.find('div').length).toBe(16);
+    expect(wrapper.find('div').length).toBe(17);
     expect(wrapper.find('.link').length).toBe(1);
   });
 });


### PR DESCRIPTION
### What does this PR do?
- Add pagination support for articles
### Description of Task to be completed?
- Create buttons for navigating to different pages.
### How should this be manually tested?
- Clone this branch 
- `npm install` to install all dependencies
- `npm start` to run the server
- On the homepage look at the bottom, you will see those buttons and be able to navigate to different pages if there are more than ten articles on the db.
### What are the relevant pivotal tracker stories?
[Pagination support for articles](https://www.pivotaltracker.com/story/show/167484554)
### Screenshot
<img width="278" alt="Screen Shot 2019-10-30 at 21 44 26" src="https://user-images.githubusercontent.com/39116572/67893021-7f22de80-fb5e-11e9-998e-9eb647b15614.png">
